### PR TITLE
Add spacing option to plot_epochs

### DIFF
--- a/spikertools/plots.py
+++ b/spikertools/plots.py
@@ -260,7 +260,7 @@ class Plots:
          else:
              plt.close()
 
-    def plot_epochs(self, event=None, epoch_window=(-0.5, 1.0), channel=None, save_path=None, show=True):
+    def plot_epochs(self, event=None, epoch_window=(-0.5, 1.0), channel=None, spacing=None, save_path=None, show=True):
         """
         Plots individual epochs of the channel data around specified events.
         
@@ -268,6 +268,8 @@ class Plots:
         - event (Event): Event to plot.
         - epoch_window (tuple): Time window around the event (pre, post) in seconds.
         - channel (Channel): Channel to analyze.
+        - spacing (float, optional): Vertical offset between epochs. If ``None``
+          (default), the standard deviation of the entire channel is used.
         - save_path (str): Path to save the plot.
         - show (bool): Whether to display the plot.
         """
@@ -310,9 +312,14 @@ class Plots:
             self.logger.warning("No epochs to plot.")
             return
 
+        if spacing is None:
+            spacing_value = np.std(channel.data)
+        else:
+            spacing_value = spacing
+
         plt.figure(figsize=(10, 6))
         for i, epoch in enumerate(epochs):
-            plt.plot(time_axis, epoch + i * np.std(epoch), color=channel.color)
+            plt.plot(time_axis, epoch + i * spacing_value, color=channel.color)
         plt.xlabel('Time (s)')
         plt.ylabel('Amplitude')
         plt.title(f'Epochs around event "{event.name}"')

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -67,7 +67,9 @@ class TestPlotting(unittest.TestCase):
 
     def test_plot_epochs(self):
         try:
-            self.session.plots.plot_epochs(event_name='1', channel_index=0, show=False)
+            event = next(e for e in self.session.events if e.name == '1')
+            channel = self.session.channels[0]
+            self.session.plots.plot_epochs(event=event, channel=channel, show=False)
         except Exception as e:
             self.fail(f'plot_epochs raised an exception: {e}')
 


### PR DESCRIPTION
## Summary
- allow user to specify spacing between epochs in `plot_epochs`
- default to channel standard deviation when spacing not provided
- adjust unit tests for new function signature

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*